### PR TITLE
商品編集、削除機能実装

### DIFF
--- a/app/controllers/detail_controller.rb
+++ b/app/controllers/detail_controller.rb
@@ -11,14 +11,16 @@ class DetailController < ApplicationController
   end
 
   def update
-    @item.update(item_params)
-    redirect_to root_path ,notice: '商品を編集しました'
+    if @item.update(item_params)
+      redirect_to root_path ,notice: '商品を編集しました'
+    else
+      redirect_to edit_detail_path
+    end
   end
 
   def destroy
-    if current_furimauser.id == @item.furimauser_id
-      @item.destroy
-      redirect_to "/"
+    if current_furimauser.id == @item.furimauser_id && @item.destroy
+      redirect_to root_path
     else
       redirect_to  detail_index_path
     end
@@ -27,7 +29,7 @@ class DetailController < ApplicationController
   private
 
   def set_item
-    @item = Item.find(5)
+    @item = Item.find(7)
   end
 
   def item_params

--- a/app/controllers/detail_controller.rb
+++ b/app/controllers/detail_controller.rb
@@ -1,4 +1,37 @@
 class DetailController < ApplicationController
+
+  before_action :set_item
+
   def index
+        redirect_to new_furimauser_session_path unless furimauser_signed_in?
+
   end
+
+  def edit
+  end
+
+  def update
+    @item.update(item_params)
+    redirect_to root_path ,notice: '商品を編集しました'
+  end
+
+  def destroy
+    if current_furimauser.id == @item.furimauser_id
+      @item.destroy
+      redirect_to "/"
+    else
+      redirect_to  detail_index_path
+    end
+  end
+
+  private
+
+  def set_item
+    @item = Item.find(5)
+  end
+
+  def item_params
+    params.require(:item).permit(:name,:price,:SaleStatu,:category_id,:explain,:postage,:region,:brand_id,:shipping_date,:size,:way_of_delivery,:quality,images_attributes:[:image1,:_destroy, :id]).merge(furimauser_id: current_furimauser.id)
+  end
+
 end

--- a/app/controllers/exhibitions_controller.rb
+++ b/app/controllers/exhibitions_controller.rb
@@ -37,7 +37,7 @@ class ExhibitionsController < ApplicationController
 private
 
   def item_params
-    params.require(:item).permit(:name,:price,:SaleStatu,:category_id,:explain,:postage,:region,:brand_id,:shipping_date,:size,:way_of_delivery,:quality,images_attributes:[:image1,:_destroy, :id])
+    params.require(:item).permit(:name,:price,:SaleStatu,:category_id,:explain,:postage,:region,:brand_id,:shipping_date,:size,:way_of_delivery,:quality,images_attributes:[:image1,:_destroy, :id]).merge(furimauser_id: current_furimauser.id)
   end
 
 end

--- a/app/models/furimauser.rb
+++ b/app/models/furimauser.rb
@@ -4,4 +4,5 @@ class Furimauser < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :cards
+  has_many :items
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,7 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :prefecture, :way_of_delively,:category_id, :quality, :postage, :shipping_date
+  belongs_to :furimauser
   has_many :images, dependent: :destroy
 
   accepts_nested_attributes_for :images, allow_destroy: true

--- a/app/views/detail/edit.html.haml
+++ b/app/views/detail/edit.html.haml
@@ -1,0 +1,168 @@
+
+%header
+  %link{href: "https://use.fontawesome.com/releases/v5.6.3/css/all.css", rel: "stylesheet"}/
+  %nav
+    %h1.main-logo
+      = image_tag "logo.png"
+    .keyword
+      %input.keywordbox{placeholder: "キーワードから探す"}/
+      %button.searchBtn{type: "submit"}
+        = image_tag "icon-search 1.png",class:"glass"
+  .linkrecord
+    .linkrecord__left
+      .links
+        = link_to "",class:"anylink" do
+          カテゴリ
+        = link_to "",class:"anylink",id:"links__right" do
+          ブランド
+    .linkrecord__right
+      .links
+        = link_to "",class:"anylink" do
+          ログイン
+        = link_to "",class:"anylink",id:"links__right" do
+          新規会員登録
+
+.big-box
+  .big-box__side-bar
+    .big-box__side-bar__mypj-box
+      .big-box__side-bar__mypj-box__title 設定
+      .big-box__side-bar__mypj-box__contents
+        = link_to "プロフィール","#"
+      .big-box__side-bar__mypj-box__contents 
+        = link_to "発送元・お届け先住所変更","#"
+      .big-box__side-bar__mypj-box__contents 
+        = link_to "支払い方法","#"
+      .big-box__side-bar__mypj-box__contents 
+        = link_to "電話番号の確認","#"
+      .big-box__side-bar__mypj-box__contents 
+        = link_to "ログアウト","#"
+  .form
+  = form_for @item,url: detail_path,method: :patch ,local: true do |f|
+    .big-box__main-box
+      .big-box__main-box__photos#image-box
+        #previews
+          - if @item.persisted?
+            - @item.images.each_with_index do |image, i|
+              = image_tag "", data: { index: i }, width: "100", height: '100'
+        = f.fields_for :images do |i|
+          .js-file_group{"data-index":i.index}
+            = i.file_field :image1, class: 'js-file'
+            %span.js-remove 
+
+
+
+
+      .big-box__main-box__form-box
+        .big-box__main-box__form-box__confirm
+        .big-box__main-box__form-box__names
+          .big-box__main-box__form-box__names__name 商品名 
+          %h1.need<※必須
+          .big-box__main-box__form-box__names__box 
+            = f.text_field :name, placeholder: "商品名（必須 40文字まで)"
+
+        .big-box__main-box__form-box__explain
+          .big-box__main-box__form-box__explain__name 商品説明
+          %h1.need<※必須
+          .big-box__main-box__form-box__explain__box
+            = f.text_area :explain
+
+        .big-box__main-box__form-box__category
+          .big-box__main-box__form-box__category__name カテゴリ
+          %h1.need<※必須
+          .big-box__main-box__form-box__category__box
+            = f.collection_select :category_id,Category.all,:id, :name
+
+        .big-box__main-box__form-box__brand
+          .big-box__main-box__form-box__brand__name ブランド
+          .big-box__main-box__form-box__brand__box
+            = f.text_field :brand_id
+
+        .big-box__main-box__form-box__size
+          .big-box__main-box__form-box__size__name サイズ
+          %h1.need<※必須
+          .big-box__main-box__form-box__size__box
+            = f.text_field :size
+          
+
+        .big-box__main-box__form-box__quarity
+          .big-box__main-box__form-box__quarity__name 商品の状態
+          %h1.need<※必須
+          .big-box__main-box__form-box__quarity__box
+            = f.collection_select :quality, Quality.all, :id, :name
+
+        .big-box__main-box__form-box__shipping-charges
+          .big-box__main-box__form-box__shipping-charges__name 配送料の負担
+          %h1.need<※必須
+          .big-box__main-box__form-box__shipping-charges__box
+            = f.collection_select :postage, Postage.all, :id, :name
+            
+        .big-box__main-box__form-box__way-of-delivary
+          .big-box__main-box__form-box__way-of-delivary__name 配送方法
+          .big-box__main-box__form-box__way-of-delivary__box
+            = f.collection_select :way_of_delivery, Way_of_delivery.all, :id, :name
+
+        .big-box__main-box__form-box__shipping-area
+          .big-box__main-box__form-box__shipping-area__name 発送元の地域
+          %h1.need<※必須
+          .big-box__main-box__form-box__shipping-area__box
+            = f.collection_select :region, Prefecture.all, :id, :name
+
+        .big-box__main-box__form-box__shipping-date
+          .big-box__main-box__form-box__shipping-date__name 発送日の目安
+          %h1.need<※必須
+          .big-box__main-box__form-box__shipping-date__box
+            = f.collection_select :shipping_date, Shipping_date.all, :id, :name
+
+        .big-box__main-box__form-box__SaleStatu 
+          .big-box__main-box__form-box__SaleStatu__name ステータス
+          %h1.need<※必須
+          .big-box__main-box__form-box__SaleStatu__box
+            = f.text_field :SaleStatu
+
+        .big-box__main-box__form-box__price
+          .big-box__main-box__form-box__price__name 商品価格
+          %h1.need<※必須
+          .big-box__main-box__form-box__price__box
+            = f.text_field :price
+        = f.submit "編集する",class:"btn-square-toy"
+    
+%footer
+  %ul.contents
+    %li.content
+      %h2.content__title FURIMAについて
+      %ul
+        %li
+          = link_to do
+            会社概要（運営会社）
+        %li
+          = link_to do 
+            プライバシーポリシー
+        %li
+          = link_to do
+            FURIMA利用規約
+        %li
+          = link_to do 
+            ポイントに関する特約
+    %li.content
+      %h2.content__title FURIMAを見る
+      %ul
+        %li
+          = link_to do
+            カテゴリー 一覧
+        %li
+          = link_to do
+            ブランド一覧
+    %li.content
+      %h2.content__title ヘルプ＆ガイド
+      %ul
+        %li
+          = link_to do
+            FURIMAガイド
+        %li
+          = link_to do
+            FURIMAロゴ利用ガイドライン
+        %li
+          = link_to do
+            お知らせ
+
+

--- a/app/views/detail/index.html.haml
+++ b/app/views/detail/index.html.haml
@@ -82,8 +82,16 @@
                   %th 発想の目安
                   %td 1~2日で発想
             .text-center
-              = link_to new_itempurchase_path, class: "item-buy-btn" do
-                購入画面に進む
+              - if furimauser_signed_in? && current_furimauser.id == @item.furimauser_id
+                = link_to edit_detail_path(@item.id), class: "item-buy-btn" do
+                  編集する
+                  %br
+                = link_to detail_path(@item.id), method: :delete, class: "item-buy-btn" do
+                  削除する
+              - else current_furimauser.id != @seller 
+                = link_to new_itempurchase_path, class: "item-buy-btn" do
+                  購入画面にすすむ
+
             .optionalArea
               %ul.good
                 %li.good_btn

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   resources :top, only: :index 
   resources :exhibitions, except: :show
   resources :user, only: :index
-  resources :detail, only: :index
+  resources :detail, only: [:index,:edit,:destroy,:update]
   resources :mypj, except: :show
   resources :fprofiles, except: :show
   resources :fadresses, except: :show

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200217083538) do
+ActiveRecord::Schema.define(version: 20200218083857) do
 
   create_table "account_adresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "furimauser_id"
@@ -37,25 +37,10 @@ ActiveRecord::Schema.define(version: 20200217083538) do
   end
 
   create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-
     t.integer  "prefecture_id"
     t.string   "city"
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
-
-    t.string   "post_number", null: false
-    t.string   "prefecture",  null: false
-    t.string   "city",        null: false
-    t.string   "town",        null: false
-    t.string   "building"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-  end
-
-  create_table "brands", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name",       null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "cards", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -65,28 +50,6 @@ ActiveRecord::Schema.define(version: 20200217083538) do
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
     t.index ["furimauser_id"], name: "index_cards_on_furimauser_id", using: :btree
-  end
-
-  create_table "comments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "use_id",                   null: false
-    t.integer  "item_id",                  null: false
-    t.text     "text",       limit: 65535, null: false
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
-
-  end
-
-  create_table "credits", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "use_id",          null: false
-    t.integer  "card_number"
-    t.integer  "year_deadline",   null: false
-    t.integer  "month_deadline",  null: false
-    t.integer  "security_number", null: false
-    t.string   "first_name",      null: false
-    t.string   "last_name",       null: false
-    t.string   "card_name",       null: false
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
   end
 
   create_table "fadresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -135,31 +98,24 @@ ActiveRecord::Schema.define(version: 20200217083538) do
   end
 
   create_table "items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name",                          null: false
-    t.integer  "price",                         null: false
-    t.integer  "category_id",                   null: false
+    t.string   "name",                           null: false
+    t.integer  "price",                          null: false
+    t.integer  "category_id",                    null: false
     t.integer  "brand_id"
-    t.text     "explain",         limit: 65535, null: false
-    t.integer  "postage",                       null: false
-    t.string   "region",                        null: false
-    t.string   "shipping_date",                 null: false
-    t.string   "size",                          null: false
-    t.string   "way_of_delivery",               null: false
-    t.string   "quality",                       null: false
-    t.string   "SaleStatu",                     null: false
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
-  end
-
-  create_table "profiles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "first_name",      null: false
-    t.string   "last_name",       null: false
-    t.string   "first_name_kana", null: false
-    t.string   "last_name_kana",  null: false
-    t.integer  "user_id",         null: false
-    t.integer  "phone_number",    null: false
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.text     "explain",          limit: 65535, null: false
+    t.integer  "postage",                        null: false
+    t.string   "region",                         null: false
+    t.string   "shipping_date",                  null: false
+    t.string   "size",                           null: false
+    t.string   "way_of_delivery",                null: false
+    t.string   "quality",                        null: false
+    t.string   "SaleStatu",                      null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.integer  "furimauser_id_id"
+    t.integer  "furimauser_id"
+    t.index ["furimauser_id"], name: "index_items_on_furimauser_id", using: :btree
+    t.index ["furimauser_id_id"], name: "index_items_on_furimauser_id_id", using: :btree
   end
 
   create_table "tops", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -173,4 +129,5 @@ ActiveRecord::Schema.define(version: 20200217083538) do
   add_foreign_key "fadresses", "furimausers"
   add_foreign_key "fprofiles", "furimausers"
   add_foreign_key "images", "items"
+  add_foreign_key "items", "furimausers"
 end


### PR DESCRIPTION
# What
商品編集、削除機能実装
- 商品の詳細ページで、投稿者だけが編集ページに遷移できるようになっている
- 商品出品時とほぼ同じUIで編集機能が実装できている
- 画像やカテゴリーの情報など、すでに登録されている商品情報は編集画面を開いた時点で、もれなく表示されるようになっている
- エラーハンドリングができている
- 商品の詳細ページで、投稿者だけが削除ボタンが押せるようになっている
- 削除ができる

# Why
間違えて出品してしまった商品を編集、削除できるようにするため

set_itemメソッドは商品詳細機能の実装がまだなので仮置きです。
@item = Item.find(5)　→　@item = Item.find(id: params[:id])に変更します